### PR TITLE
chore(deps): `@node-ipc/vanilla-test@1.4.12`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,30 @@
 {
   "name": "@achrinza/strong-type",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@achrinza/strong-type",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "devDependencies": {
-        "@node-ipc/vanilla-test": "1.4.9",
+        "@node-ipc/vanilla-test": "1.4.12",
         "c8": "^7.6.0",
         "copyfiles": "^2.4.1",
         "node-http-server": "8.1.5"
       },
       "engines": {
-        "node": "^12.21.0 || 14 || 15 || 16 || 17 || 18"
+        "node": "^12.21.0 || 14 || 15 || 16 || 17 || 18 || 19"
+      }
+    },
+    "node_modules/@achrinza/strong-type": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-1.1.3.tgz",
+      "integrity": "sha512-BCfMeStjIofJBZWSSbmkSLm0SRCAF58Aj5hz7as80A+bQOgQn5PsyWo61dbW1kyVidddHAPcj0wMFfLSeInl1Q==",
+      "dev": true,
+      "engines": {
+        "node": "^12.21.0 || 14 || 15 || 16 || 17 || 18 || 19"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -34,13 +43,13 @@
       }
     },
     "node_modules/@node-ipc/vanilla-test": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@node-ipc/vanilla-test/-/vanilla-test-1.4.9.tgz",
-      "integrity": "sha512-IqPnrzj2eMoBoHuxT9/Pr5/bbwIBlVskDu1Rrp7pbUAjeKjXqOdms3udfi34d6nknWPm///6Spyc7wwydKaxiw==",
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@node-ipc/vanilla-test/-/vanilla-test-1.4.12.tgz",
+      "integrity": "sha512-1P9Gln651fMwhNDktYF4skU7EObURn2mrDiMmYvbUT63yb6IQb+kOUA1LFKeyv6oV3S7GA7+3ux+MsXtSa0LWA==",
       "dev": true,
       "dependencies": {
-        "ansi-colors-es6": "5.0.0",
-        "strong-type": "1.1.0"
+        "@achrinza/strong-type": "1.1.3",
+        "ansi-colors-es6": "5.0.0"
       },
       "engines": {
         "node": ">=12.21.0"
@@ -670,15 +679,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strong-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strong-type/-/strong-type-1.1.0.tgz",
-      "integrity": "sha512-X5Z6riticuH5GnhUyzijfDi1SoXas8ODDyN7K8lJeQK+Jfi4dKdoJGL4CXTskY/ATBcN+rz5lROGn1tAUkOX7g==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.21.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -871,6 +871,12 @@
     }
   },
   "dependencies": {
+    "@achrinza/strong-type": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-1.1.3.tgz",
+      "integrity": "sha512-BCfMeStjIofJBZWSSbmkSLm0SRCAF58Aj5hz7as80A+bQOgQn5PsyWo61dbW1kyVidddHAPcj0wMFfLSeInl1Q==",
+      "dev": true
+    },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -884,13 +890,13 @@
       "dev": true
     },
     "@node-ipc/vanilla-test": {
-      "version": "1.4.9",
-      "resolved": "https://registry.npmjs.org/@node-ipc/vanilla-test/-/vanilla-test-1.4.9.tgz",
-      "integrity": "sha512-IqPnrzj2eMoBoHuxT9/Pr5/bbwIBlVskDu1Rrp7pbUAjeKjXqOdms3udfi34d6nknWPm///6Spyc7wwydKaxiw==",
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@node-ipc/vanilla-test/-/vanilla-test-1.4.12.tgz",
+      "integrity": "sha512-1P9Gln651fMwhNDktYF4skU7EObURn2mrDiMmYvbUT63yb6IQb+kOUA1LFKeyv6oV3S7GA7+3ux+MsXtSa0LWA==",
       "dev": true,
       "requires": {
-        "ansi-colors-es6": "5.0.0",
-        "strong-type": "1.1.0"
+        "@achrinza/strong-type": "1.1.3",
+        "ansi-colors-es6": "5.0.0"
       }
     },
     "@types/is-windows": {
@@ -1376,12 +1382,6 @@
       "requires": {
         "ansi-regex": "^5.0.0"
       }
-    },
-    "strong-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strong-type/-/strong-type-1.1.0.tgz",
-      "integrity": "sha512-X5Z6riticuH5GnhUyzijfDi1SoXas8ODDyN7K8lJeQK+Jfi4dKdoJGL4CXTskY/ATBcN+rz5lROGn1tAUkOX7g==",
-      "dev": true
     },
     "supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "homepage": "https://github.com/achrinza/strong-type#readme",
   "devDependencies": {
+    "@node-ipc/vanilla-test": "1.4.12",
     "c8": "^7.6.0",
     "copyfiles": "^2.4.1",
-    "node-http-server": "8.1.5",
-    "@node-ipc/vanilla-test": "1.4.9"
+    "node-http-server": "8.1.5"
   }
 }


### PR DESCRIPTION
Update to `@node-ipc/vanilla-test@1.4.12` for recursive Node.js v19 engine support

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>