### PR TITLE
chore: support Node.js v21

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "tag": "v0-latest"
   },
   "engines": {
-    "node": "12 || 13 || 14 || 15 || 16 || 17 || 18 || 19 || 20"
+    "node": "12 || 13 || 14 || 15 || 16 || 17 || 18 || 19 || 20 || 21"
   },
   "scripts": {
     "test": "npm run emulate && node ./test/CI.js",


### PR DESCRIPTION
Update `engines` in `package.json`

see: https://github.com/achrinza/node-ipc/issues/54